### PR TITLE
Add support for serialization and deserialization of 128-bit integers.

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -67,9 +67,11 @@ impl<'de, 'a> serde::Deserializer<'de> for &'a mut Deserializer<'de> {
     impl_nums!(u16, deserialize_u16, visit_u16, read_u16);
     impl_nums!(u32, deserialize_u32, visit_u32, read_u32);
     impl_nums!(u64, deserialize_u64, visit_u64, read_u64);
+    impl_nums!(u64, deserialize_u128, visit_u128, read_u128);
     impl_nums!(i16, deserialize_i16, visit_i16, read_i16);
     impl_nums!(i32, deserialize_i32, visit_i32, read_i32);
     impl_nums!(i64, deserialize_i64, visit_i64, read_i64);
+    impl_nums!(i128, deserialize_i128, visit_i128, read_i128);
     impl_nums!(f32, deserialize_f32, visit_f32, read_f32);
     impl_nums!(f64, deserialize_f64, visit_f64, read_f64);
 

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -77,6 +77,13 @@ where
     }
 
     #[inline]
+    fn serialize_u128(self, v: u128) -> Result<()> {
+        self.writer
+            .write_u128::<NativeEndian>(v)
+            .map_err(From::from)
+    }
+
+    #[inline]
     fn serialize_i8(self, v: i8) -> Result<()> {
         self.writer.write_i8(v).map_err(From::from)
     }
@@ -99,6 +106,13 @@ where
     fn serialize_i64(self, v: i64) -> Result<()> {
         self.writer
             .write_i64::<NativeEndian>(v)
+            .map_err(From::from)
+    }
+
+    #[inline]
+    fn serialize_i128(self, v: i128) -> Result<()> {
+        self.writer
+            .write_i128::<NativeEndian>(v)
             .map_err(From::from)
     }
 

--- a/tests/bincode.rs
+++ b/tests/bincode.rs
@@ -2,17 +2,35 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
 struct Foo {
-    bar: String,
-    baz: u64,
-    derp: bool,
+    some_str: String,
+    some_u8: u8,
+    some_u16: u16,
+    some_u32: u32,
+    some_u64: u64,
+    some_u128: u128,
+    some_i8: i8,
+    some_i16: i16,
+    some_i32: i32,
+    some_i64: i64,
+    some_i128: i128,
+    some_bool: bool,
 }
 
 impl Default for Foo {
     fn default() -> Self {
         Foo {
-            bar: "hello".into(),
-            baz: 1337u64,
-            derp: true,
+            some_str: "hello".into(),
+            some_u8: 42u8,
+            some_u16: 1337u16,
+            some_u32: 1337u32,
+            some_u64: 1337u64,
+            some_u128: 1337u128,
+            some_i8: 42i8,
+            some_i16: 1337i16,
+            some_i32: 1337i32,
+            some_i64: 1337i64,
+            some_i128: 1337i128,
+            some_bool: true,
         }
     }
 }


### PR DESCRIPTION
Also adds tests for other integer sizes.

Fixes #5, though I'd appreciate if you have ideas how to correctly support the conditional support of 128-bit integers, or let me know if you think that's unnecessary.