### PR TITLE
Add postcard flavor for serializing into preallocated Vec

### DIFF
--- a/benches/bincode.rs
+++ b/benches/bincode.rs
@@ -2,6 +2,9 @@
 
 extern crate test;
 
+mod flavor;
+
+use crate::flavor::PreallocatedVec;
 use serde::{Deserialize, Serialize};
 use test::Bencher;
 
@@ -52,7 +55,10 @@ fn postcard_deserialize(b: &mut Bencher) {
 fn postcard_serialize(b: &mut Bencher) {
     let foo = Foo::default();
 
-    b.iter(|| postcard::to_stdvec(&foo).unwrap());
+    b.iter(|| {
+        let mut bytes = Vec::with_capacity(128);
+        postcard::serialize_with_flavor(&foo, PreallocatedVec::new(&mut bytes)).unwrap()
+    });
 }
 
 #[bench]

--- a/benches/flavor/mod.rs
+++ b/benches/flavor/mod.rs
@@ -1,0 +1,33 @@
+use postcard::ser_flavors::Flavor;
+use postcard::Result;
+
+pub struct PreallocatedVec<'a> {
+    vec: &'a mut Vec<u8>,
+}
+
+impl<'a> PreallocatedVec<'a> {
+    pub fn new(vec: &'a mut Vec<u8>) -> Self {
+        PreallocatedVec { vec }
+    }
+}
+
+impl<'a> Flavor for PreallocatedVec<'a> {
+    type Output = ();
+
+    #[inline]
+    fn try_extend(&mut self, data: &[u8]) -> Result<()> {
+        self.vec.extend_from_slice(data);
+        Ok(())
+    }
+
+    #[inline]
+    fn try_push(&mut self, data: u8) -> Result<()> {
+        self.vec.push(data);
+        Ok(())
+    }
+
+    #[inline]
+    fn finalize(self) -> Result<Self::Output> {
+        Ok(())
+    }
+}


### PR DESCRIPTION
Postcard previously looked unfairly bad in this benchmark because it has no built-in API equivalent to bincode's `serialize_into`.

```diff
  test bincode_deserialize  ... bench:          31 ns/iter (+/- 1)
  test bincode_serialize    ... bench:          19 ns/iter (+/- 2)
  test postcard_deserialize ... bench:          31 ns/iter (+/- 2)
- test postcard_serialize   ... bench:          54 ns/iter (+/- 1)
+ test postcard_serialize   ... bench:          21 ns/iter (+/- 1)
  test serde_deserialize    ... bench:          24 ns/iter (+/- 0)
  test serde_serialize      ... bench:          13 ns/iter (+/- 0)
```