### PR TITLE
Update to bincode 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ byteorder = "1.4.3"
 serde = "1.0.166"
 
 [dev-dependencies]
-bincode = "1.0"
+bincode = { version = "2", features = ["derive", "serde"] }
 postcard = { version = "1.0", features = ["use-std"] }
 serde = { version = "1.0", features = ["derive"] }
 

--- a/tests/bincode.rs
+++ b/tests/bincode.rs
@@ -27,7 +27,7 @@ impl Default for Foo {
 fn test_ser() {
     let foo = Foo::default();
 
-    let bincode_bytes = bincode::serialize(&foo).unwrap();
+    let bincode_bytes = bincode::serde::encode_to_vec(&foo, bincode::config::legacy()).unwrap();
 
     let mut serde_bytes = Vec::new();
     serde_bench::serialize(&mut serde_bytes, &foo).unwrap();
@@ -41,7 +41,10 @@ fn test_de() {
     let mut bytes = Vec::new();
     serde_bench::serialize(&mut bytes, &foo).unwrap();
 
-    let bincode_foo = bincode::deserialize::<Foo>(&bytes).unwrap();
+    let bincode_foo =
+        bincode::serde::decode_from_slice::<Foo, _>(&bytes, bincode::config::legacy())
+            .unwrap()
+            .0;
     assert_eq!(bincode_foo, foo);
 
     let serde_foo = serde_bench::deserialize::<Foo>(&bytes).unwrap();


### PR DESCRIPTION
```console
test bincode_decode            ... bench:          46.38 ns/iter (+/- 1.96)
test bincode_encode            ... bench:          11.25 ns/iter (+/- 0.17)
test bincode_serde_deserialize ... bench:          40.27 ns/iter (+/- 0.75)
test bincode_serde_serialize   ... bench:          11.26 ns/iter (+/- 0.11)
test postcard_deserialize      ... bench:          29.30 ns/iter (+/- 0.98)
test postcard_serialize        ... bench:          13.72 ns/iter (+/- 0.11)
test serde_deserialize         ... bench:          24.81 ns/iter (+/- 0.56)
test serde_serialize           ... bench:           6.21 ns/iter (+/- 0.05)
```