### PR TITLE
Raise rustc to 1.68

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [nightly, beta, stable, 1.85.0, 1.61.0]
+        rust: [nightly, beta, stable, 1.85.0, 1.68.0]
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
@@ -28,7 +28,7 @@ jobs:
           toolchain: ${{matrix.rust}}
       - run: cargo check
       - run: cargo test
-        if: matrix.rust != '1.61.0'
+        if: matrix.rust != '1.68.0'
       - run: cargo bench --no-run
         if: matrix.rust == 'nightly'
       - uses: actions/upload-artifact@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ include = ["Cargo.toml", "src/**/*.rs"]
 keywords = ["serde", "serialization"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/serde-rs/bench"
-rust-version = "1.61"
+rust-version = "1.68"
 
 [dependencies]
 byteorder = "1.4.3"


### PR DESCRIPTION
CI is so slow without Cargo sparse registry protocol (Rust 1.68+). 19 seconds vs 160 seconds.